### PR TITLE
Date filter is still showing 2012

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ database.yml
 
 # Ignore IDE configurations
 .idea
+atlassian-ide-plugin.xml
+*.iml
 
 # Ignore all logfiles and tempfiles.
 /log/*.log

--- a/app/assets/javascripts/hiring.js
+++ b/app/assets/javascripts/hiring.js
@@ -34,11 +34,12 @@
 
   function setYearsSlider(){
       var srcParamsEl = $('#search_params');
-      $( "#years_slider" ).slider({
+	  var currentYear = new Date().getFullYear();
+	  $( "#years_slider" ).slider({
           range: true,
           min: 1950,
-          max: 2012,
-          values: [ 1950, 2012 ],
+          max: currentYear,
+          values: [ 1950, currentYear ],
           slide: function( event, ui ) {
               $( "#years_range" ).html(ui.values[ 0 ] + " - " + ui.values[ 1 ] );
           },

--- a/app/assets/javascripts/home.js
+++ b/app/assets/javascripts/home.js
@@ -452,11 +452,12 @@ var loadGmap = (function() {
 
   function setSlider(){
       var srcParamsEl = $('#search_params');
-      $( "#years_slider" ).slider({
-          range: true,
-          min: 1950,
-          max: 2012,
-          values: [ 1950, 2012 ],
+	  var currentYear = new Date().getFullYear();
+	  $( "#years_slider" ).slider({
+		  range: true,
+		  min: 1950,
+		  max: currentYear,
+		  values: [ 1950, currentYear ],
           slide: function( event, ui ) {
               $( "#years_range" ).html(ui.values[ 0 ] + " - " + ui.values[ 1 ] );
 


### PR DESCRIPTION
The date slider filter is still showing 2012 as the maximum year. This should probably be dynamic so that it changes with the current year.
![screenshot_5_5_13_12_38_pm](https://f.cloud.github.com/assets/3146164/463962/18e6a50e-b5b3-11e2-9c0d-a7e7d999947f.png)
