### PR TITLE
Overrode homepage_url to ensure returned URL is valid

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -144,6 +144,9 @@ class Company < ActiveRecord::Base
           where("companies.zipcode_id = ?", id)
         }
 
+  def homepage_url
+    absolute_url read_attribute :homepage_url
+  end
 
   def is_hiring?
     (self.jobs_count || 0) > 0
@@ -187,6 +190,10 @@ class Company < ActiveRecord::Base
   private
   def attach_county
     self.county = city.county unless city.county.nil?
+  end
+
+  def absolute_url(url)
+    url.match(/http?[\S]:\/\//) ? url : "http://"+url
   end
 
   def self.find_geocode(address, city_name, zip_code)


### PR DESCRIPTION
There are several company homepage urls that do not begin with the protocol http:// or https://. 6kites is an example of the issue. Their string returned by the attribute homepage_url on Company is www.6kites.com. When haml generates the href it assumes it should generate a relative url http://www.bdnewtech.com/www.6kites.com. This generates a 404. It's a small but annoying problem.