### PR TITLE
Add Ramen to NewTech site

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,9 @@ gem 'simple-navigation-bootstrap'
 # make beautifull with awesome icons
 gem 'font-awesome-sass-rails'
 
+# Ramen
+gem 'ramen-rails', '~>0.4.0'
+
 # HAML
 gem 'haml-rails'
 

--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ group :development do
    # Deploy with Capistrano
    gem 'capistrano'
    gem 'rvm-capistrano'
-   gem 'therubyracer'
+   gem 'therubyracer', '0.12.2'
    gem 'thin'
    gem 'debugger'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ end
 group :development do
    # Deploy with Capistrano
    gem 'capistrano'
-   gem 'rvm-capistrano'
+   gem 'rvm-capistrano', require: false
    gem 'therubyracer', '0.12.2'
    gem 'thin'
    gem 'debugger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,7 +160,7 @@ GEM
     kgio (2.8.0)
     launchy (2.2.0)
       addressable (~> 2.3)
-    libv8 (3.11.8.13)
+    libv8 (3.16.14.7)
     mail (2.5.3)
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
@@ -227,7 +227,7 @@ GEM
     rake (10.0.4)
     rdoc (3.12.2)
       json (~> 1.4)
-    ref (1.0.2)
+    ref (1.0.5)
     responders (0.9.3)
       railties (~> 3.1)
     rest-client (1.6.7)
@@ -259,8 +259,8 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    therubyracer (0.11.4)
-      libv8 (~> 3.11.8.12)
+    therubyracer (0.12.2)
+      libv8 (~> 3.16.14.0)
       ref
     thin (1.5.1)
       daemons (>= 1.0.9)
@@ -339,9 +339,12 @@ DEPENDENCIES
   seed-fu (~> 2.2.0)
   simple-navigation-bootstrap
   simple_form
-  therubyracer
+  therubyracer (= 0.12.2)
   thin
   turbo-sprockets-rails3
   twitter
   uglifier (= 1.0.3)
   unicorn
+
+BUNDLED WITH
+   1.10.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,6 +225,8 @@ GEM
       thor (>= 0.14.6, < 2.0)
     raindrops (0.10.0)
     rake (10.0.4)
+    ramen-rails (0.4.0)
+      activesupport (>= 3.0)
     rdoc (3.12.2)
       json (~> 1.4)
     ref (1.0.5)
@@ -330,6 +332,7 @@ DEPENDENCIES
   pg (= 0.14.0)
   rabl
   rails (= 3.2.13)
+  ramen-rails (~> 0.4.0)
   responders
   rmagick
   rolify (= 3.1.0)

--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -16,6 +16,10 @@ configatron.app_name = ENV['APP_NAME']
 configatron.secret_token = ENV['SECRET_TOKEN']
 configatron.session_store = ENV['SESSION_STORE']
 
+# Ramen
+configatron.ramen.organization_id = ENV['RAMEN_ORGANIZATION_ID']
+configatron.ramen.organization_secret = ENV['RAMEN_ORGANIZATION_SECRET']
+
 # Email
 configatron.email.delivery_method = ( ENV['EMAIL_DELIVERY_METHOD'] || "smtp" ).to_sym
 configatron.email.enable_starttls_auto = ENV['EMAIL_START_SSL']

--- a/config/initializers/ramen.rb
+++ b/config/initializers/ramen.rb
@@ -1,0 +1,54 @@
+RamenRails.config do |config|
+  # Your Ramen Organization ID
+  config.organization_id = configatron.ramen.organization_id 
+
+  # Your Ramen Organization Secret
+  config.organization_secret = configatron.ramen.organization_secret 
+
+
+  ## Important note regarding `-> {}` vs. `Proc.new {}`
+  ##
+  ## Use `Proc.new {}` and not `-> {}`. There's some inconsistency
+  ## in how instance_eval works across Ruby versions that will bite
+  ## you in the butt otherwise.
+
+
+  ## How we access the currently logged in user. This object
+  ## should respond to #email(String), #id(String),
+  ## #created_at(Time) and #name(String)
+  #
+  # config.current_user = Proc.new { current_user }
+
+
+  ## How we access the labels for the currently logged in user.
+  ## This is an array of strings.
+  #
+  # config.current_user_labels = Proc.new { current_user.labels.map(&:name) }
+
+
+  ## How we access the current user "value". This is
+  ## a Float. It can represent whatever you want.
+  ##
+  ## If config.current_user is empty, this will be ignored
+  #
+  # config.current_user_value = Proc.new { current_user_value }
+
+
+  ## Custom Links to add to the Ramen Tray
+  ## You can add up to 3. Each requires a `title`.
+  ## Each requires a `callback` or an `href`.
+  ## Links w/ `href` will have target="_blank".
+  ## `callback` is a *string*, not a JS closure even
+  ## if you override these values in your markup.
+  #
+  # config.custom_links = [
+  #   {
+  #     title: "Submit a bug",
+  #     callback: "$('#submit_bug').modal('show')"  #<-- String!
+  #   },
+  #   {
+  #     title: "Knowledge Base",
+  #     href: "/knowedge_base"
+  #   }
+  # ]
+end


### PR DESCRIPTION
You'll need to set some variables in .env. I'll send along an invitation for the New Tech organization on Ramen to Robert in a moment so he can get the keys and add them. Let me know if anyone else should be added.

A couples notes:
* The migrations failed. It looks like the SkillType model was expunged, but `20130801161600_add_stars_to_skill_type.rb` still tries to add a column. I commented that out and migrations ran successfully, but `rake system:bootstrap` still failed on seeding.
* Because of that ^, I was not able to run the app locally to verify the installation.
* I had to update therubyracer version so it would install on OSX Yosemite.

Let me know how else I can help get this running on BDNT. Thanks!