### PR TITLE
Map styling to allow zoom and readable filters

### DIFF
--- a/app/assets/javascripts/home.js
+++ b/app/assets/javascripts/home.js
@@ -52,6 +52,7 @@
         panControl: false,
         zoomControl: true,
         zoomControlOptions: {
+          position: google.maps.ControlPosition.LEFT_CENTER,
           style: google.maps.ZoomControlStyle.SMALL
         },
         mapTypeControl: false,

--- a/app/assets/stylesheets/home.css.scss
+++ b/app/assets/stylesheets/home.css.scss
@@ -8,7 +8,7 @@
   top: 138px;
   left: 0px;
   width:100%;
-  height:100%;
+  bottom:0px;
   z-index: -999;
 }
 

--- a/app/assets/stylesheets/home.css.scss
+++ b/app/assets/stylesheets/home.css.scss
@@ -230,6 +230,9 @@
   color: #9aafba;
   min-width: 1100px;
 
+  background: white;
+  opacity: 0.9;
+
   .slider-container {
     height: 100%;
     padding-top: 1px;


### PR DESCRIPTION
I've tested the CSS in Chrome/OSX but haven't built the app from scratch due to ruby dependency problems here.

Changes:
- pin the map to the bottom of window instead of using height = 100% which overflows the viewport.
- white background for filter bar so it's readable when the events header is collapsed.
- move the map zoom controls to left side / vertical center.